### PR TITLE
#7 Update log type/label and message

### DIFF
--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -14,141 +14,139 @@
 package main
 
 import (
-    "fmt"
-    "C"
-    "unsafe"
-    "strings"
+	"C"
+	"fmt"
+	"strings"
+	"unsafe"
 
-    "github.com/aws/amazon-kinesis-streams-for-fluent-bit/kinesis"
-    "github.com/aws/amazon-kinesis-firehose-for-fluent-bit/plugins"
-    "github.com/fluent/fluent-bit-go/output"
-    "github.com/sirupsen/logrus"
+	"github.com/aws/amazon-kinesis-firehose-for-fluent-bit/plugins"
+	"github.com/aws/amazon-kinesis-streams-for-fluent-bit/kinesis"
+	"github.com/fluent/fluent-bit-go/output"
+	"github.com/sirupsen/logrus"
 )
 
 var (
-    pluginInstances []*kinesis.OutputPlugin
+	pluginInstances []*kinesis.OutputPlugin
 )
 
 func addPluginInstance(ctx unsafe.Pointer) error {
-    pluginID := len(pluginInstances)
-    output.FLBPluginSetContext(ctx, pluginID)
-    instance, err := newKinesisOutput(ctx, pluginID)
-    if err != nil {
-        return err
-    }
+	pluginID := len(pluginInstances)
+	output.FLBPluginSetContext(ctx, pluginID)
+	instance, err := newKinesisOutput(ctx, pluginID)
+	if err != nil {
+		return err
+	}
 
-    pluginInstances = append(pluginInstances, instance)
-    return nil
+	pluginInstances = append(pluginInstances, instance)
+	return nil
 }
 
 func getPluginInstance(ctx unsafe.Pointer) *kinesis.OutputPlugin {
-    pluginID := output.FLBPluginGetContext(ctx).(int)
-    return pluginInstances[pluginID]
+	pluginID := output.FLBPluginGetContext(ctx).(int)
+	return pluginInstances[pluginID]
 }
-
 
 func newKinesisOutput(ctx unsafe.Pointer, pluginID int) (*kinesis.OutputPlugin, error) {
-    stream := output.FLBPluginConfigKey(ctx, "stream")
-    logrus.Infof("[kinesis %d] plugin parameter stream = '%s'", pluginID, stream)
-    region := output.FLBPluginConfigKey(ctx, "region")
-    logrus.Infof("[kinesis %d] plugin parameter region = '%s'", pluginID, region)
-    dataKeys := output.FLBPluginConfigKey(ctx, "data_keys")
-    logrus.Infof("[kinesis %d] plugin parameter data_keys = '%s'", pluginID, dataKeys)
-    partitionKey := output.FLBPluginConfigKey(ctx, "partition_key")
-    logrus.Infof("[kinesis %d] plugin parameter partition_key = '%s'", pluginID, partitionKey)
-    roleARN := output.FLBPluginConfigKey(ctx, "role_arn")
-    logrus.Infof("[kinesis %d] plugin parameter role_arn = '%s'", pluginID, roleARN)
-    endpoint := output.FLBPluginConfigKey(ctx, "endpoint")
-    logrus.Infof("[kinesis %d] plugin parameter endpoint = '%s'", pluginID, endpoint)
-    appendNewline := output.FLBPluginConfigKey(ctx, "append_newline")
-    logrus.Infof("[kinesis %d] plugin parameter append_newline = %s", pluginID, appendNewline)
+	stream := output.FLBPluginConfigKey(ctx, "stream")
+	logrus.Infof("[kinesis %d] plugin parameter stream = '%s'", pluginID, stream)
+	region := output.FLBPluginConfigKey(ctx, "region")
+	logrus.Infof("[kinesis %d] plugin parameter region = '%s'", pluginID, region)
+	dataKeys := output.FLBPluginConfigKey(ctx, "data_keys")
+	logrus.Infof("[kinesis %d] plugin parameter data_keys = '%s'", pluginID, dataKeys)
+	partitionKey := output.FLBPluginConfigKey(ctx, "partition_key")
+	logrus.Infof("[kinesis %d] plugin parameter partition_key = '%s'", pluginID, partitionKey)
+	roleARN := output.FLBPluginConfigKey(ctx, "role_arn")
+	logrus.Infof("[kinesis %d] plugin parameter role_arn = '%s'", pluginID, roleARN)
+	endpoint := output.FLBPluginConfigKey(ctx, "endpoint")
+	logrus.Infof("[kinesis %d] plugin parameter endpoint = '%s'", pluginID, endpoint)
+	appendNewline := output.FLBPluginConfigKey(ctx, "append_newline")
+	logrus.Infof("[kinesis %d] plugin parameter append_newline = %s", pluginID, appendNewline)
 
-    if stream == "" || region == "" {
-        return nil, fmt.Errorf("[kinesis %d] stream and region are required configuration parameters", pluginID)
-    }
+	if stream == "" || region == "" {
+		return nil, fmt.Errorf("[kinesis %d] stream and region are required configuration parameters", pluginID)
+	}
 
-    if partitionKey == "log" {
-        return nil, fmt.Errorf("[kinesis %d] 'log' cannot be set as the partition key", pluginID)
-    }
+	if partitionKey == "log" {
+		return nil, fmt.Errorf("[kinesis %d] 'log' cannot be set as the partition key", pluginID)
+	}
 
-    if partitionKey == "" {
-        logrus.Infof("[kinesis %d] no partition key provided. A random one will be generated.", pluginID)
-    }
+	if partitionKey == "" {
+		logrus.Infof("[kinesis %d] no partition key provided. A random one will be generated.", pluginID)
+	}
 
-    appendNL := false
-    if  strings.ToLower(appendNewline) == "true" {
-        appendNL = true
-    }
-    return kinesis.NewOutputPlugin(region, stream, dataKeys, partitionKey, roleARN, endpoint, appendNL, pluginID)
+	appendNL := false
+	if strings.ToLower(appendNewline) == "true" {
+		appendNL = true
+	}
+	return kinesis.NewOutputPlugin(region, stream, dataKeys, partitionKey, roleARN, endpoint, appendNL, pluginID)
 }
-
 
 // The "export" comments have syntactic meaning
 // This is how the compiler knows a function should be callable from the C code
 
 //export FLBPluginRegister
 func FLBPluginRegister(ctx unsafe.Pointer) int {
-    return output.FLBPluginRegister(ctx, "kinesis", "Amazon Kinesis Data Streams Fluent Bit Plugin.")
+	return output.FLBPluginRegister(ctx, "kinesis", "Amazon Kinesis Data Streams Fluent Bit Plugin.")
 }
 
 //export FLBPluginInit
-func  FLBPluginInit(ctx unsafe.Pointer) int {
-    plugins.SetupLogger()
-    err := addPluginInstance(ctx)
-    if err != nil {
-        logrus.Errorf("[kinesis] Failed to initialize plugin: %v\n", err)
-        return output.FLB_ERROR
-    }
-    return output.FLB_OK
+func FLBPluginInit(ctx unsafe.Pointer) int {
+	plugins.SetupLogger()
+	err := addPluginInstance(ctx)
+	if err != nil {
+		logrus.Errorf("[kinesis] Failed to initialize plugin: %v\n", err)
+		return output.FLB_ERROR
+	}
+	return output.FLB_OK
 }
 
 //export FLBPluginFlushCtx
 func FLBPluginFlushCtx(ctx, data unsafe.Pointer, length C.int, tag *C.char) int {
-    var count int
-    var ret int
-    var record map[interface{}]interface{}
+	var count int
+	var ret int
+	var record map[interface{}]interface{}
 
-    // Create Fluent Bit decoder
-    dec := output.NewDecoder(data, int(length))
+	// Create Fluent Bit decoder
+	dec := output.NewDecoder(data, int(length))
 
-    kinesisOutput := getPluginInstance(ctx)
-    fluentTag := C.GoString(tag)
-    logrus.Debugf("[kinesis %d] Found logs with tag: %s\n", kinesisOutput.PluginID, fluentTag)
+	kinesisOutput := getPluginInstance(ctx)
+	fluentTag := C.GoString(tag)
+	logrus.Debugf("[kinesis %d] Found logs with tag: %s\n", kinesisOutput.PluginID, fluentTag)
 
-    for {
-        //Extract Record
-        ret, _, record = output.GetRecord(dec)
-        if ret != 0 {
-            break
-        }
+	for {
+		//Extract Record
+		ret, _, record = output.GetRecord(dec)
+		if ret != 0 {
+			break
+		}
 
-        retCode := kinesisOutput.AddRecord(record)
-        if retCode != output.FLB_OK {
-            return retCode
-        }
-        count++
-    }
-    err := kinesisOutput.Flush()
-    if err != nil {
-        logrus.Errorf("[kinesis %d] %v\n", kinesisOutput.PluginID, err)
-        return output.FLB_ERROR
-    }
-    logrus.Debugf("[kinesis %d] Processed %d events with tag %s\n", kinesisOutput.PluginID, count, fluentTag)
+		retCode := kinesisOutput.AddRecord(record)
+		if retCode != output.FLB_OK {
+			return retCode
+		}
+		count++
+	}
+	err := kinesisOutput.Flush()
+	if err != nil {
+		logrus.Errorf("[kinesis %d] %v\n", kinesisOutput.PluginID, err)
+		return output.FLB_ERROR
+	}
+	logrus.Debugf("[kinesis %d] Processed %d events with tag %s\n", kinesisOutput.PluginID, count, fluentTag)
 
-    return output.FLB_OK
+	return output.FLB_OK
 }
 
 //export FLBPluginExit
 func FLBPluginExit() int {
-    // Before final exit, call Flush() for all the instances of the Output Plugin
-    for i := range pluginInstances {
-        err := pluginInstances[i].Flush()
-        if err != nil {
-            logrus.Errorf("[kinesis %d] %v\n", pluginInstances[i].PluginID, err)
-        }
-    }
+	// Before final exit, call Flush() for all the instances of the Output Plugin
+	for i := range pluginInstances {
+		err := pluginInstances[i].Flush()
+		if err != nil {
+			logrus.Errorf("[kinesis %d] %v\n", pluginInstances[i].PluginID, err)
+		}
+	}
 
-    return output.FLB_OK
+	return output.FLB_OK
 }
 
 func main() {

--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -15,315 +15,315 @@
 package kinesis
 
 import (
-    "fmt"
-    "os"
-    "time"
-    "math/rand"
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
 
-    "github.com/aws/amazon-kinesis-firehose-for-fluent-bit/plugins"
-    "github.com/aws/aws-sdk-go/aws"
-    "github.com/aws/aws-sdk-go/aws/awserr"
-    "github.com/aws/aws-sdk-go/aws/credentials/stscreds"
-    "github.com/aws/aws-sdk-go/aws/endpoints"
-    "github.com/aws/aws-sdk-go/aws/session"
-    "github.com/aws/aws-sdk-go/service/kinesis"
-    fluentbit "github.com/fluent/fluent-bit-go/output"
-    jsoniter "github.com/json-iterator/go"
-    "github.com/sirupsen/logrus"
+	"github.com/aws/amazon-kinesis-firehose-for-fluent-bit/plugins"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/kinesis"
+	fluentbit "github.com/fluent/fluent-bit-go/output"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/sirupsen/logrus"
 )
 
 const (
-    partitionKeyCharset = "abcdefghijklmnopqrstuvwxyz" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	partitionKeyCharset = "abcdefghijklmnopqrstuvwxyz" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 )
 
 const (
-    // Kinesis API Limit https://docs.aws.amazon.com/sdk-for-go/api/service/kinesis/#Kinesis.PutRecords
-    maximumRecordsPerPut        = 500
-    maximumPutRecordBatchSize   = 1024 * 1024 * 5 // 5 MB
-    maximumRecordSize           = 1024 * 1024 // 1 MB
+	// Kinesis API Limit https://docs.aws.amazon.com/sdk-for-go/api/service/kinesis/#Kinesis.PutRecords
+	maximumRecordsPerPut      = 500
+	maximumPutRecordBatchSize = 1024 * 1024 * 5 // 5 MB
+	maximumRecordSize         = 1024 * 1024     // 1 MB
 
-    partitionKeyMaxLength       = 256
+	partitionKeyMaxLength = 256
 )
 
 // PutRecordsClient contains the kinesis PutRecords method call
-type PutRecordsClient interface{
-    PutRecords(input *kinesis.PutRecordsInput) (*kinesis.PutRecordsOutput, error)
+type PutRecordsClient interface {
+	PutRecords(input *kinesis.PutRecordsInput) (*kinesis.PutRecordsOutput, error)
 }
 
 type random struct {
-    seededRandom    *rand.Rand
-    buffer          []byte
+	seededRandom *rand.Rand
+	buffer       []byte
 }
 
 // OutputPlugin sends log records to kinesis
 type OutputPlugin struct {
-    // The name of the stream that you want log records sent to
-    stream                          string
-    // If specified, only these keys and values will be send as the log record
-    dataKeys                        string
-    // If specified, the value of that data key will be used as the partition key. 
-    // Otherwise a random string will be used.
-    // Partition key decides in which shard of your stream the data belongs to
-    partitionKey                    string
-    // Decides whether to append a newline after each data record
-    appendNewline                   bool
-    lastInvalidPartitionKeyIndex    int
-    client                          PutRecordsClient
-    records                         []*kinesis.PutRecordsRequestEntry
-    dataLength                      int
-    backoff                         *plugins.Backoff
-    timer                           *plugins.Timeout
-    PluginID                        int
-    random                          *random
+	// The name of the stream that you want log records sent to
+	stream string
+	// If specified, only these keys and values will be send as the log record
+	dataKeys string
+	// If specified, the value of that data key will be used as the partition key.
+	// Otherwise a random string will be used.
+	// Partition key decides in which shard of your stream the data belongs to
+	partitionKey string
+	// Decides whether to append a newline after each data record
+	appendNewline                bool
+	lastInvalidPartitionKeyIndex int
+	client                       PutRecordsClient
+	records                      []*kinesis.PutRecordsRequestEntry
+	dataLength                   int
+	backoff                      *plugins.Backoff
+	timer                        *plugins.Timeout
+	PluginID                     int
+	random                       *random
 }
 
 // NewOutputPlugin creates an OutputPlugin object
 func NewOutputPlugin(region, stream, dataKeys, partitionKey, roleARN, endpoint string, appendNewline bool, pluginID int) (*OutputPlugin, error) {
-    client, err := newPutRecordsClient(roleARN, region, endpoint)
-    if err != nil {
-        return nil, err
-    }
+	client, err := newPutRecordsClient(roleARN, region, endpoint)
+	if err != nil {
+		return nil, err
+	}
 
-    records := make([]*kinesis.PutRecordsRequestEntry, 0, maximumRecordsPerPut)
-    timer, err := plugins.NewTimeout(func (d time.Duration) {
-        logrus.Errorf("[kinesis %d] timeout threshold reached: Failed to send logs for %s\n", pluginID, d.String())
-        logrus.Errorf("[kinesis %d] Quitting Fluent Bit", pluginID)
-        os.Exit(1)
-    })
+	records := make([]*kinesis.PutRecordsRequestEntry, 0, maximumRecordsPerPut)
+	timer, err := plugins.NewTimeout(func(d time.Duration) {
+		logrus.Errorf("[kinesis %d] timeout threshold reached: Failed to send logs for %s\n", pluginID, d.String())
+		logrus.Errorf("[kinesis %d] Quitting Fluent Bit", pluginID)
+		os.Exit(1)
+	})
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
-    random := &random{
-        seededRandom:   seededRand,
-        buffer:         make([]byte, 8),
-    }
+	seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	random := &random{
+		seededRandom: seededRand,
+		buffer:       make([]byte, 8),
+	}
 
-    return &OutputPlugin{
-        stream:                         stream,
-        client:                         client,
-        records:                        records,
-        dataKeys:                       dataKeys,
-        partitionKey:                   partitionKey,
-        appendNewline:                  appendNewline,
-        lastInvalidPartitionKeyIndex:   -1,
-        backoff:                        plugins.NewBackoff(),
-        timer:                          timer,
-        PluginID:                       pluginID,
-        random:                         random,
-    }, nil
+	return &OutputPlugin{
+		stream:                       stream,
+		client:                       client,
+		records:                      records,
+		dataKeys:                     dataKeys,
+		partitionKey:                 partitionKey,
+		appendNewline:                appendNewline,
+		lastInvalidPartitionKeyIndex: -1,
+		backoff:                      plugins.NewBackoff(),
+		timer:                        timer,
+		PluginID:                     pluginID,
+		random:                       random,
+	}, nil
 }
 
 // newPutRecordsClient creates the Kinesis client for calling the PutRecords method
 func newPutRecordsClient(roleARN string, awsRegion string, endpoint string) (*kinesis.Kinesis, error) {
-    sess, err := session.NewSession(&aws.Config{
-        Region: aws.String(awsRegion),
-    })
-    if err != nil {
-        return nil, err
-    }
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(awsRegion),
+	})
+	if err != nil {
+		return nil, err
+	}
 
-    svcConfig := &aws.Config{}
-    if endpoint != "" {
-        defaultResolver := endpoints.DefaultResolver()
-        cwCustomResolverFn := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
-            if service == "kinesis" {
-                return  endpoints.ResolvedEndpoint{
-                    URL: endpoint,
-                }, nil
-            }
-            return defaultResolver.EndpointFor(service, region, optFns...)
-        }
-        svcConfig.EndpointResolver = endpoints.ResolverFunc(cwCustomResolverFn)
-    }
+	svcConfig := &aws.Config{}
+	if endpoint != "" {
+		defaultResolver := endpoints.DefaultResolver()
+		cwCustomResolverFn := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+			if service == "kinesis" {
+				return endpoints.ResolvedEndpoint{
+					URL: endpoint,
+				}, nil
+			}
+			return defaultResolver.EndpointFor(service, region, optFns...)
+		}
+		svcConfig.EndpointResolver = endpoints.ResolverFunc(cwCustomResolverFn)
+	}
 
-    if roleARN != "" {
-        creds := stscreds.NewCredentials(sess, roleARN)
-        svcConfig.Credentials = creds
-    }
+	if roleARN != "" {
+		creds := stscreds.NewCredentials(sess, roleARN)
+		svcConfig.Credentials = creds
+	}
 
-    client := kinesis.New(sess, svcConfig)
-    client.Handlers.Build.PushBackNamed(plugins.CustomUserAgentHandler())
-    return client, nil
+	client := kinesis.New(sess, svcConfig)
+	client.Handlers.Build.PushBackNamed(plugins.CustomUserAgentHandler())
+	return client, nil
 }
 
 // AddRecord accepts a record and adds it to the buffer, flushing the buffer if it is full
 // the return value is one of: FLB_OK FLB_RETRY
 // API Errors lead to an FLB_RETRY, and data processing errors are logged, the record is discarded and FLB_OK is returned
 func (outputPlugin *OutputPlugin) AddRecord(record map[interface{}]interface{}) int {
-    data, err := outputPlugin.processRecord(record)
-    if err != nil {
-        logrus.Errorf("[kinesis %d] %v\n", outputPlugin.PluginID, err)
-        // discard this single bad record instead and let the batch continue
-        return fluentbit.FLB_OK
-    }
+	data, err := outputPlugin.processRecord(record)
+	if err != nil {
+		logrus.Errorf("[kinesis %d] %v\n", outputPlugin.PluginID, err)
+		// discard this single bad record instead and let the batch continue
+		return fluentbit.FLB_OK
+	}
 
-    newDataSize := len(data)
+	newDataSize := len(data)
 
-    if len(outputPlugin.records) == maximumRecordsPerPut || (outputPlugin.dataLength+newDataSize) > maximumPutRecordBatchSize {
-        err = outputPlugin.sendCurrentBatch()
-        if err != nil {
-            logrus.Errorf("[kinesis %d] %v\n", outputPlugin.PluginID, err)
-            // If FluentBit fails to send logs, it will retry rather than discarding the logs
-            return fluentbit.FLB_RETRY
-        }
-    }
+	if len(outputPlugin.records) == maximumRecordsPerPut || (outputPlugin.dataLength+newDataSize) > maximumPutRecordBatchSize {
+		err = outputPlugin.sendCurrentBatch()
+		if err != nil {
+			logrus.Errorf("[kinesis %d] %v\n", outputPlugin.PluginID, err)
+			// If FluentBit fails to send logs, it will retry rather than discarding the logs
+			return fluentbit.FLB_RETRY
+		}
+	}
 
-    partitionKey := outputPlugin.getPartitionKey(record)
-    outputPlugin.records = append(outputPlugin.records, &kinesis.PutRecordsRequestEntry{
-        Data: data,
-        PartitionKey: aws.String(partitionKey),
-    })
-    outputPlugin.dataLength += newDataSize
-    return fluentbit.FLB_OK
+	partitionKey := outputPlugin.getPartitionKey(record)
+	outputPlugin.records = append(outputPlugin.records, &kinesis.PutRecordsRequestEntry{
+		Data:         data,
+		PartitionKey: aws.String(partitionKey),
+	})
+	outputPlugin.dataLength += newDataSize
+	return fluentbit.FLB_OK
 }
 
 // Flush sends the current buffer of log records
 func (outputPlugin *OutputPlugin) Flush() error {
-    return outputPlugin.sendCurrentBatch()
+	return outputPlugin.sendCurrentBatch()
 }
 
 func (outputPlugin *OutputPlugin) processRecord(record map[interface{}]interface{}) ([]byte, error) {
-    if outputPlugin.dataKeys != "" {
-        record = plugins.DataKeys(outputPlugin.dataKeys, record)
-    }
+	if outputPlugin.dataKeys != "" {
+		record = plugins.DataKeys(outputPlugin.dataKeys, record)
+	}
 
-    var err error
-    record, err = plugins.DecodeMap(record)
-    if err != nil {
-        logrus.Debugf("[kinesis %d] Failed to decode record: %v\n", outputPlugin.PluginID, record)
-        return nil, err
-    }
+	var err error
+	record, err = plugins.DecodeMap(record)
+	if err != nil {
+		logrus.Debugf("[kinesis %d] Failed to decode record: %v\n", outputPlugin.PluginID, record)
+		return nil, err
+	}
 
-    var json = jsoniter.ConfigCompatibleWithStandardLibrary
-    data, err := json.Marshal(record)
-    if err != nil {
-        logrus.Debugf("[kinesis %d] Failed to marshal record: %v\n", outputPlugin.PluginID, record)
-        return nil, err
-    }
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	data, err := json.Marshal(record)
+	if err != nil {
+		logrus.Debugf("[kinesis %d] Failed to marshal record: %v\n", outputPlugin.PluginID, record)
+		return nil, err
+	}
 
-    // append a newline after each log record
-    if outputPlugin.appendNewline {
-        data = append(data, []byte("\n")...)
-    }
+	// append a newline after each log record
+	if outputPlugin.appendNewline {
+		data = append(data, []byte("\n")...)
+	}
 
-    if len(data) > maximumRecordSize {
-        return nil, fmt.Errorf("Log record greater than max size allowed by Kinesis")
-    }
+	if len(data) > maximumRecordSize {
+		return nil, fmt.Errorf("Log record greater than max size allowed by Kinesis")
+	}
 
-    return data, nil
+	return data, nil
 }
 
 func (outputPlugin *OutputPlugin) sendCurrentBatch() error {
-    if outputPlugin.lastInvalidPartitionKeyIndex >= 0 {
-        logrus.Errorf("[kinesis %d] Invalid partition key. Failed to find partition_key %s in log record %s", outputPlugin.PluginID, outputPlugin.partitionKey, outputPlugin.records[outputPlugin.lastInvalidPartitionKeyIndex].Data)
-        outputPlugin.lastInvalidPartitionKeyIndex = -1
-    }
-    outputPlugin.backoff.Wait()
-    outputPlugin.timer.Check()
+	if outputPlugin.lastInvalidPartitionKeyIndex >= 0 {
+		logrus.Errorf("[kinesis %d] Invalid partition key. Failed to find partition_key %s in log record %s", outputPlugin.PluginID, outputPlugin.partitionKey, outputPlugin.records[outputPlugin.lastInvalidPartitionKeyIndex].Data)
+		outputPlugin.lastInvalidPartitionKeyIndex = -1
+	}
+	outputPlugin.backoff.Wait()
+	outputPlugin.timer.Check()
 
-    response, err := outputPlugin.client.PutRecords(&kinesis.PutRecordsInput{
-        Records:    outputPlugin.records,
-        StreamName: aws.String(outputPlugin.stream),
-    })
-    if err != nil {
-        logrus.Errorf("[kinesis %d] PutRecords failed with %v\n", outputPlugin.PluginID, err)
-        outputPlugin.timer.Start()
-        if aerr, ok := err.(awserr.Error); ok {
-            if aerr.Code() == kinesis.ErrCodeProvisionedThroughputExceededException {
-                logrus.Warnf("[kinesis %d] Throughput limits for the stream may have been exceeded.", outputPlugin.PluginID)
-                // Backoff and Retry
-                outputPlugin.backoff.StartBackoff()
-            }
-        }
-        return err
-    }
-    logrus.Debugf("[kinesis %d] Sent %d events to Kinesis\n", outputPlugin.PluginID, len(outputPlugin.records))
+	response, err := outputPlugin.client.PutRecords(&kinesis.PutRecordsInput{
+		Records:    outputPlugin.records,
+		StreamName: aws.String(outputPlugin.stream),
+	})
+	if err != nil {
+		logrus.Errorf("[kinesis %d] PutRecords failed with %v\n", outputPlugin.PluginID, err)
+		outputPlugin.timer.Start()
+		if aerr, ok := err.(awserr.Error); ok {
+			if aerr.Code() == kinesis.ErrCodeProvisionedThroughputExceededException {
+				logrus.Warnf("[kinesis %d] Throughput limits for the stream may have been exceeded.", outputPlugin.PluginID)
+				// Backoff and Retry
+				outputPlugin.backoff.StartBackoff()
+			}
+		}
+		return err
+	}
+	logrus.Debugf("[kinesis %d] Sent %d events to Kinesis\n", outputPlugin.PluginID, len(outputPlugin.records))
 
-    return outputPlugin.processAPIResponse(response)
+	return outputPlugin.processAPIResponse(response)
 }
 
 // processAPIResponse processes the successful and failed records
 // it returns an error iff no records succeeded (i.e.) no progress has been made
 func (outputPlugin *OutputPlugin) processAPIResponse(response *kinesis.PutRecordsOutput) error {
-    if aws.Int64Value(response.FailedRecordCount) > 0 {
-        // start timer if all records failed (no progress has been made)
-        if aws.Int64Value(response.FailedRecordCount) == int64(len(outputPlugin.records)) {
-            outputPlugin.timer.Start()
-            return fmt.Errorf("PutRecords request returned with no records successfully recieved")
-        }
+	if aws.Int64Value(response.FailedRecordCount) > 0 {
+		// start timer if all records failed (no progress has been made)
+		if aws.Int64Value(response.FailedRecordCount) == int64(len(outputPlugin.records)) {
+			outputPlugin.timer.Start()
+			return fmt.Errorf("PutRecords request returned with no records successfully recieved")
+		}
 
-        logrus.Errorf("[kinesis %d] %d records failed to be delivered\n", outputPlugin.PluginID, aws.Int64Value(response.FailedRecordCount))
-        failedRecords := make([]*kinesis.PutRecordsRequestEntry, 0, aws.Int64Value(response.FailedRecordCount))
-        // try to resend failed records
-        for i, record := range response.Records {
-            if record.ErrorMessage != nil {
-                logrus.Debugf("[kinesis %d] Record failed to send with error: %s\n", outputPlugin.PluginID, aws.StringValue(record.ErrorMessage))
-                failedRecords = append(failedRecords, outputPlugin.records[i])
-            }
-            if aws.StringValue(record.ErrorCode) == kinesis.ErrCodeProvisionedThroughputExceededException {
-                // Backoff and Retry
-                outputPlugin.backoff.StartBackoff()
-            }
-        }
+		logrus.Warnf("[kinesis %d] %d records failed to be delivered. Will retry.\n", outputPlugin.PluginID, aws.Int64Value(response.FailedRecordCount))
+		failedRecords := make([]*kinesis.PutRecordsRequestEntry, 0, aws.Int64Value(response.FailedRecordCount))
+		// try to resend failed records
+		for i, record := range response.Records {
+			if record.ErrorMessage != nil {
+				logrus.Debugf("[kinesis %d] Record failed to send with error: %s\n", outputPlugin.PluginID, aws.StringValue(record.ErrorMessage))
+				failedRecords = append(failedRecords, outputPlugin.records[i])
+			}
+			if aws.StringValue(record.ErrorCode) == kinesis.ErrCodeProvisionedThroughputExceededException {
+				// Backoff and Retry
+				outputPlugin.backoff.StartBackoff()
+			}
+		}
 
-        outputPlugin.records = outputPlugin.records[:0]
-        outputPlugin.records = append(outputPlugin.records, failedRecords...)
-        outputPlugin.dataLength = 0
-        for _, record := range outputPlugin.records {
-            outputPlugin.dataLength += len(record.Data)
-        }
-    } else {
-        // request fully succeeded
-        outputPlugin.timer.Reset()
-        outputPlugin.backoff.Reset()
-        outputPlugin.records = outputPlugin.records[:0]
-        outputPlugin.dataLength = 0
-    }
-    return nil
+		outputPlugin.records = outputPlugin.records[:0]
+		outputPlugin.records = append(outputPlugin.records, failedRecords...)
+		outputPlugin.dataLength = 0
+		for _, record := range outputPlugin.records {
+			outputPlugin.dataLength += len(record.Data)
+		}
+	} else {
+		// request fully succeeded
+		outputPlugin.timer.Reset()
+		outputPlugin.backoff.Reset()
+		outputPlugin.records = outputPlugin.records[:0]
+		outputPlugin.dataLength = 0
+	}
+	return nil
 }
 
 // randomString generates a random string of length 8
 // it uses the math/rand library
 func (outputPlugin *OutputPlugin) randomString() string {
-    for i := range outputPlugin.random.buffer {
-        outputPlugin.random.buffer[i] = partitionKeyCharset[outputPlugin.random.seededRandom.Intn(len(partitionKeyCharset))]
-    }
-    return string(outputPlugin.random.buffer)
+	for i := range outputPlugin.random.buffer {
+		outputPlugin.random.buffer[i] = partitionKeyCharset[outputPlugin.random.seededRandom.Intn(len(partitionKeyCharset))]
+	}
+	return string(outputPlugin.random.buffer)
 }
 
 // getPartitionKey returns the value for a given valid key
 // if the given key is emapty or invalid, it returns a random string
 func (outputPlugin *OutputPlugin) getPartitionKey(record map[interface{}]interface{}) string {
-    partitionKey := outputPlugin.partitionKey
-    if partitionKey != "" {
-        for k, v := range record {
-            dataKey := stringOrByteArray(k)
-            if(dataKey == partitionKey) {
-                value := stringOrByteArray(v)
-                if(value != "") {
-                    if len(value) > partitionKeyMaxLength {
-                        value = value[0:partitionKeyMaxLength]
-                    }
-                    return value
-                }
-            }
-        }
-        outputPlugin.lastInvalidPartitionKeyIndex = len(outputPlugin.records)
-     }
-    return outputPlugin.randomString()
+	partitionKey := outputPlugin.partitionKey
+	if partitionKey != "" {
+		for k, v := range record {
+			dataKey := stringOrByteArray(k)
+			if dataKey == partitionKey {
+				value := stringOrByteArray(v)
+				if value != "" {
+					if len(value) > partitionKeyMaxLength {
+						value = value[0:partitionKeyMaxLength]
+					}
+					return value
+				}
+			}
+		}
+		outputPlugin.lastInvalidPartitionKeyIndex = len(outputPlugin.records)
+	}
+	return outputPlugin.randomString()
 }
 
-// stringOrByteArray returns the string value if the input is a string or byte array otherwise an empty string 
+// stringOrByteArray returns the string value if the input is a string or byte array otherwise an empty string
 func stringOrByteArray(v interface{}) string {
-    switch t := v.(type) {
-        case []byte:
-            return string(t)
-        case string:
-            return t
-        default:
-            return ""
-    }
+	switch t := v.(type) {
+	case []byte:
+		return string(t)
+	case string:
+		return t
+	default:
+		return ""
+	}
 }

--- a/kinesis/kinesis_test.go
+++ b/kinesis/kinesis_test.go
@@ -1,101 +1,101 @@
 package kinesis
 
 import (
-    "os"
-    "time"
-    "math/rand"
-    "testing"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
 
-    "github.com/aws/amazon-kinesis-firehose-for-fluent-bit/plugins"
-    "github.com/aws/aws-sdk-go/service/kinesis"
-    "github.com/stretchr/testify/assert"
-    "github.com/sirupsen/logrus"
-    "github.com/golang/mock/gomock"
-    "github.com/aws/aws-sdk-go/aws"
-    "github.com/aws/amazon-kinesis-streams-for-fluent-bit/kinesis/mock_kinesis"
-    fluentbit "github.com/fluent/fluent-bit-go/output"
+	"github.com/aws/amazon-kinesis-firehose-for-fluent-bit/plugins"
+	"github.com/aws/amazon-kinesis-streams-for-fluent-bit/kinesis/mock_kinesis"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kinesis"
+	fluentbit "github.com/fluent/fluent-bit-go/output"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 // newMockOutputPlugin creates an mock OutputPlugin object
 func newMockOutputPlugin(client *mock_kinesis.MockPutRecordsClient) (*OutputPlugin, error) {
-    records := make([]*kinesis.PutRecordsRequestEntry, 0, 500)
+	records := make([]*kinesis.PutRecordsRequestEntry, 0, 500)
 
-    timer, _ := plugins.NewTimeout(func (d time.Duration) {
-        logrus.Errorf("[kinesis] timeout threshold reached: Failed to send logs for %v", d)
-        logrus.Errorf("[kinesis] Quitting Fluent Bit")
-        os.Exit(1)
-    })
+	timer, _ := plugins.NewTimeout(func(d time.Duration) {
+		logrus.Errorf("[kinesis] timeout threshold reached: Failed to send logs for %v", d)
+		logrus.Errorf("[kinesis] Quitting Fluent Bit")
+		os.Exit(1)
+	})
 
-    seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
-    b := make([]byte, 8)
-    random := &random{
-        seededRandom:   seededRand,
-        buffer:         b,
-    }
+	seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	b := make([]byte, 8)
+	random := &random{
+		seededRandom: seededRand,
+		buffer:       b,
+	}
 
-    return &OutputPlugin{
-        stream:                         "stream",
-        client:                         client,
-        records:                        records,
-        dataKeys:                       "",
-        partitionKey:                   "",
-        lastInvalidPartitionKeyIndex:   -1,
-        backoff:                        plugins.NewBackoff(),
-        timer:                          timer,
-        PluginID:                       0,
-        random:                         random,
-    }, nil
+	return &OutputPlugin{
+		stream:                       "stream",
+		client:                       client,
+		records:                      records,
+		dataKeys:                     "",
+		partitionKey:                 "",
+		lastInvalidPartitionKeyIndex: -1,
+		backoff:                      plugins.NewBackoff(),
+		timer:                        timer,
+		PluginID:                     0,
+		random:                       random,
+	}, nil
 }
 
 // Test cases for TestStringOrByteArray
 var testCases = []struct {
-    input   interface{}
-    output  string
+	input  interface{}
+	output string
 }{
-    {"testString", "testString"},
-    {35344, ""},
-    {[]byte{'b', 'y', 't', 'e'}, "byte"},
-    {nil, ""},
+	{"testString", "testString"},
+	{35344, ""},
+	{[]byte{'b', 'y', 't', 'e'}, "byte"},
+	{nil, ""},
 }
 
 func TestStringOrByteArray(t *testing.T) {
-    for _, testCase := range testCases {
-        result := stringOrByteArray(testCase.input)
-        if result != testCase.output {
-            t.Errorf("[Test Failed] Expeced: %s, Returned: %s", testCase.output, result)
-        }
-    }
+	for _, testCase := range testCases {
+		result := stringOrByteArray(testCase.input)
+		if result != testCase.output {
+			t.Errorf("[Test Failed] Expeced: %s, Returned: %s", testCase.output, result)
+		}
+	}
 }
 
 func TestAddRecord(t *testing.T) {
-    record := map[interface{}]interface{} {
-        "testkey":  []byte("test value"),
-    }
+	record := map[interface{}]interface{}{
+		"testkey": []byte("test value"),
+	}
 
-    outputPlugin, _ := newMockOutputPlugin(nil)
+	outputPlugin, _ := newMockOutputPlugin(nil)
 
-    retCode := outputPlugin.AddRecord(record)
-    assert.Equal(t, retCode, fluentbit.FLB_OK, "Expected return code to be FLB_OK")
-    assert.Len(t, outputPlugin.records, 1, "Expected output to contain 1 record")
+	retCode := outputPlugin.AddRecord(record)
+	assert.Equal(t, retCode, fluentbit.FLB_OK, "Expected return code to be FLB_OK")
+	assert.Len(t, outputPlugin.records, 1, "Expected output to contain 1 record")
 }
 
 func TestAddRecordAndFlush(t *testing.T) {
-    record := map[interface{}]interface{} {
-        "testkey": []byte("test value"),
-    }
+	record := map[interface{}]interface{}{
+		"testkey": []byte("test value"),
+	}
 
-    ctrl := gomock.NewController(t)
-    mockKinesis := mock_kinesis.NewMockPutRecordsClient(ctrl)
+	ctrl := gomock.NewController(t)
+	mockKinesis := mock_kinesis.NewMockPutRecordsClient(ctrl)
 
-    mockKinesis.EXPECT().PutRecords(gomock.Any()).Return(&kinesis.PutRecordsOutput{
-        FailedRecordCount: aws.Int64(0),
-    }, nil)
+	mockKinesis.EXPECT().PutRecords(gomock.Any()).Return(&kinesis.PutRecordsOutput{
+		FailedRecordCount: aws.Int64(0),
+	}, nil)
 
-    outputPlugin, _ := newMockOutputPlugin(mockKinesis)
+	outputPlugin, _ := newMockOutputPlugin(mockKinesis)
 
-    retCode := outputPlugin.AddRecord(record)
-    assert.Equal(t, retCode, fluentbit.FLB_OK, "Expected return code to be FLB_OK")
+	retCode := outputPlugin.AddRecord(record)
+	assert.Equal(t, retCode, fluentbit.FLB_OK, "Expected return code to be FLB_OK")
 
-    err := outputPlugin.Flush()
-    assert.NoError(t, err, "Unexpected error calling flush")
+	err := outputPlugin.Flush()
+	assert.NoError(t, err, "Unexpected error calling flush")
 }


### PR DESCRIPTION
*Issue #, if available:*
#7 

*Description of changes:*
When a request fails to send data to Kinesis Stream, we print a error log and retry. In this change, we are updatring the label of the log from 'error' to 'warning', and also updating the log message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
