### PR TITLE
Added option to replace dots in keys with underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ If you think you’ve found a potential security issue, please do not post it in
 * `role_arn`: ARN of an IAM role to assume (for cross account access).
 * `endpoint`: Specify a custom endpoint for the Kinesis Streams API.
 * `append_newline`: If you set append_newline as true, a newline will be addded after each log record.
+* `replace_dots`: If you set replace_dots as true, all dots in key names will be replaced with underscores.
 
 ### Permissions
 
@@ -48,6 +49,7 @@ This plugin has been tested with Fluent Bit 1.2.0+. It may not work with older F
     stream          my-kinesis-stream-name
     partition_key   container_id
     append_newline  true
+    replace_dots    true
 ```
 
 ### AWS for Fluent Bit

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -61,6 +61,8 @@ func newKinesisOutput(ctx unsafe.Pointer, pluginID int) (*kinesis.OutputPlugin, 
 	logrus.Infof("[kinesis %d] plugin parameter endpoint = '%s'", pluginID, endpoint)
 	appendNewline := output.FLBPluginConfigKey(ctx, "append_newline")
 	logrus.Infof("[kinesis %d] plugin parameter append_newline = %s", pluginID, appendNewline)
+	replaceDots := output.FLBPluginConfigKey(ctx, "replace_dots")
+	logrus.Infof("[kinesis %d] plugin parameter replace_dots = %s", pluginID, replaceDots)
 
 	if stream == "" || region == "" {
 		return nil, fmt.Errorf("[kinesis %d] stream and region are required configuration parameters", pluginID)
@@ -78,6 +80,12 @@ func newKinesisOutput(ctx unsafe.Pointer, pluginID int) (*kinesis.OutputPlugin, 
 	if strings.ToLower(appendNewline) == "true" {
 		appendNL = true
 	}
+
+	replaceDotsInKeys := false
+	if strings.ToLower(replaceDots) == "true" {
+		replaceDotsInKeys = true
+	}
+
 	return kinesis.NewOutputPlugin(region, stream, dataKeys, partitionKey, roleARN, endpoint, appendNL, pluginID)
 }
 

--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -190,8 +190,6 @@ func (outputPlugin *OutputPlugin) Flush() error {
 }
 
 func replaceDots(obj map[interface{}]interface{}) map[interface{}]interface{} {
-	newObj := make(map[interface{}]interface{})
-
 	for k, v := range obj {
 		switch kt := k.(type) {
 		case string:
@@ -201,18 +199,12 @@ func replaceDots(obj map[interface{}]interface{}) map[interface{}]interface{} {
 		switch vt := v.(type) {
 		case map[interface{}]interface{}:
 			v = replaceDots(vt)
-			// Ensure duplicated keys are merged rather than replaced
-			if _, ok := newObj[k]; ok {
-				for nestedK, nestedV := range vt {
-					newObj[k].(map[interface{}]interface{})[nestedK] = nestedV
-				}
-			}
 		}
 
-		newObj[k] = v
+		obj[k] = v
 	}
 
-	return newObj
+	return obj
 }
 
 func (outputPlugin *OutputPlugin) processRecord(record map[interface{}]interface{}) ([]byte, error) {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Add an option to replace dots (`.`) within keys with underscores (`_`) to help avoid type clashes in Elasticsearch and similar.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
