### PR TITLE
Incorrect maximum record size

### DIFF
--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -43,7 +43,7 @@ const (
 const (
 	// Kinesis API Limit https://docs.aws.amazon.com/sdk-for-go/api/service/kinesis/#Kinesis.PutRecords
 	maximumRecordsPerPut      = 500
-	maximumPutRecordBatchSize = 1024 * 1024 * 5 // 5 MB
+	maximumPutRecordBatchSize = 1024 * 1024 * 5 - partitionKeyMaxLength // 5 MB
 	maximumRecordSize         = 1024 * 1024     // 1 MB
 
 	partitionKeyMaxLength = 256


### PR DESCRIPTION
*Issue #21,

*Description of changes:*

Sending logs fails due to too large size with the message:


`time="2020-03-18T10:46:26Z" level=error msg="[kinesis 0] PutRecords failed with InvalidArgumentException: Records size exceeds 5 MB limit\n\tstatus code: 400, request id: d576e1fc-22dc-c659-839d-1fbe02a45df7\n"`

The reason behind is the wrong value for maximumPutRecordBatchSize. The docs say "a limit of 5 MB for the entire request, including partition keys."
https://docs.aws.amazon.com/sdk-for-go/api/service/kinesis/#Kinesis.PutRecords

Below change fixes the problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
