### PR TITLE
Fix: Update logic to calculate the maximum record size

### DIFF
--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -196,9 +196,9 @@ func (outputPlugin *OutputPlugin) AddRecord(record map[interface{}]interface{}, 
 		return fluentbit.FLB_OK
 	}
 
-	newDataSize := len(data)
+	newRecordSize := len(data) + len(partitionKey)
 
-	if len(outputPlugin.records) == maximumRecordsPerPut || (outputPlugin.dataLength+newDataSize+len(partitionKey)) > maximumPutRecordBatchSize {
+	if len(outputPlugin.records) == maximumRecordsPerPut || (outputPlugin.dataLength+newRecordSize) > maximumPutRecordBatchSize {
 		err = outputPlugin.sendCurrentBatch()
 		if err != nil {
 			logrus.Errorf("[kinesis %d] %v\n", outputPlugin.PluginID, err)
@@ -211,7 +211,7 @@ func (outputPlugin *OutputPlugin) AddRecord(record map[interface{}]interface{}, 
 		Data:         data,
 		PartitionKey: aws.String(partitionKey),
 	})
-	outputPlugin.dataLength += (newDataSize + len(partitionKey))
+	outputPlugin.dataLength += newRecordSize
 	return fluentbit.FLB_OK
 }
 


### PR DESCRIPTION
*Issue #21 

*Description of changes:*
Maximum record size for kinesis stream `PutRecords` is 5mb including the size of partition keys. Earlier, we only considered the size of `data` part of each record. This fix will stop the unexpected limit exceeds exception. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
