### PR TITLE
Experimental: Concurrently flush records in goroutines

### DIFF
--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -128,6 +128,7 @@ func FLBPluginFlushCtx(ctx, data unsafe.Pointer, length C.int, tag *C.char) int 
 
 func flushWithRetries(kinesisOutput *kinesis.OutputPlugin, tag *C.char, count int, records []*kinesisAPI.PutRecordsRequestEntry, retries int) {
 	for i := 0; i < retries; i++ {
+		// TODO: Would probably want to backoff before retrying?
 		retCode := pluginConcurrentFlush(kinesisOutput, tag, count, records)
 		if retCode != output.FLB_RETRY {
 			break

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -167,18 +167,13 @@ func unpackRecords(data unsafe.Pointer, length C.int) (records []map[interface{}
 		if record == nil {
 			logrus.Info("unpack: null record")
 			all_good = false
+		}
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		data, err := json.Marshal(record)
+		if err == nil {
+			logrus.Infof("unpack 2: %s\n", string(data))
 		} else {
-			var json = jsoniter.ConfigCompatibleWithStandardLibrary
-			data, err := json.Marshal(record)
-			if err == nil {
-				if len(data) == 0 {
-					logrus.Info("unpack: record has zero length")
-					all_good = false
-				}
-			} else {
-				logrus.Info("unpack: unmarshal error")
-				all_good = false
-			}
+			logrus.Info("unpack 2: unmarshal error")
 		}
 
 		records = append(records, record)
@@ -196,12 +191,12 @@ func unpackRecords(data unsafe.Pointer, length C.int) (records []map[interface{}
 	for i := 0; i < count; i++ {
 		record = records[i]
 		if record == nil {
-			logrus.Infof("unpack: %d is null\n", i)
+			logrus.Infof("unpack 2: %d is null\n", i)
 		}
 		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		data, err := json.Marshal(record)
 		if err == nil {
-			logrus.Infof("unpack: %s\n", string(data))
+			logrus.Infof("unpack 2: %s\n", string(data))
 		} else {
 			logrus.Info("unpack 2: unmarshal error")
 		}

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -144,10 +144,9 @@ func FLBPluginFlushCtx(ctx, data unsafe.Pointer, length C.int, tag *C.char) int 
 		}
 		count++
 	}
-	err := kinesisOutput.Flush()
-	if err != nil {
-		logrus.Errorf("[kinesis %d] %v\n", kinesisOutput.PluginID, err)
-		return output.FLB_ERROR
+	retCode := kinesisOutput.Flush()
+	if retCode != output.FLB_OK {
+		return retCode
 	}
 	logrus.Debugf("[kinesis %d] Processed %d events with tag %s\n", kinesisOutput.PluginID, count, fluentTag)
 
@@ -158,10 +157,7 @@ func FLBPluginFlushCtx(ctx, data unsafe.Pointer, length C.int, tag *C.char) int 
 func FLBPluginExit() int {
 	// Before final exit, call Flush() for all the instances of the Output Plugin
 	for i := range pluginInstances {
-		err := pluginInstances[i].Flush()
-		if err != nil {
-			logrus.Errorf("[kinesis %d] %v\n", pluginInstances[i].PluginID, err)
-		}
+		pluginInstances[i].Flush()
 	}
 
 	return output.FLB_OK

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -182,11 +182,10 @@ func pluginConcurrentFlush(ctx, data unsafe.Pointer, length C.int, tag *C.char) 
 
 //export FLBPluginExit
 func FLBPluginExit() int {
-	records := make([]*kinesisAPI.PutRecordsRequestEntry, 0, maximumRecordsPerPut)
 	// Before final exit, call Flush() for all the instances of the Output Plugin
-	for i := range pluginInstances {
-		pluginInstances[i].Flush(records)
-	}
+	// for i := range pluginInstances {
+	// 	pluginInstances[i].Flush(records)
+	// }
 
 	return output.FLB_OK
 }

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -165,13 +165,13 @@ func pluginConcurrentFlush(ctx, data unsafe.Pointer, length C.int, tag *C.char) 
 			timestamp = time.Now()
 		}
 
-		retCode := kinesisOutput.AddRecord(records, record, &timestamp)
+		retCode := kinesisOutput.AddRecord(&records, record, &timestamp)
 		if retCode != output.FLB_OK {
 			return retCode
 		}
 		count++
 	}
-	retCode := kinesisOutput.Flush(records)
+	retCode := kinesisOutput.Flush(&records)
 	if retCode != output.FLB_OK {
 		return retCode
 	}

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -170,7 +170,7 @@ func unpackRecords(data unsafe.Pointer, length C.int) (records []map[interface{}
 		} else {
 			var json = jsoniter.ConfigCompatibleWithStandardLibrary
 			data, err := json.Marshal(record)
-			if err != nil {
+			if err == nil {
 				if len(data) == 0 {
 					logrus.Info("unpack: record has zero length")
 					all_good = false

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -168,6 +168,7 @@ func unpackRecords(data unsafe.Pointer, length C.int) (records []map[interface{}
 			logrus.Info("unpack: null record")
 			all_good = false
 		}
+		logrus.Info("unpack: %v", record)
 		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		data, err := json.Marshal(record)
 		if err == nil {
@@ -190,6 +191,7 @@ func unpackRecords(data unsafe.Pointer, length C.int) (records []map[interface{}
 
 	for i := 0; i < count; i++ {
 		record = records[i]
+		logrus.Info("unpack 2: %v", record)
 		if record == nil {
 			logrus.Infof("unpack 2: %d is null\n", i)
 		}

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -175,6 +175,9 @@ func unpackRecords(data unsafe.Pointer, length C.int) (records []map[interface{}
 					logrus.Info("unpack: record has zero length")
 					all_good = false
 				}
+			} else {
+				logrus.Info("unpack: unmarshal error")
+				all_good = false
 			}
 		}
 

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -138,6 +138,7 @@ func unpackRecords(data unsafe.Pointer, length C.int) (records []map[interface{}
 	var timestamp time.Time
 	var record map[interface{}]interface{}
 	count = 0
+	all_good := true
 
 	records = make([]map[interface{}]interface{}, 100)
 	timestamps = make([]time.Time, 100)
@@ -165,11 +166,15 @@ func unpackRecords(data unsafe.Pointer, length C.int) (records []map[interface{}
 
 		if record == nil {
 			logrus.Info("unpack: null record")
+			all_good = false
 		} else {
 			var json = jsoniter.ConfigCompatibleWithStandardLibrary
 			data, err := json.Marshal(record)
 			if err != nil {
-				logrus.Infof("unpack: %s\n", err)
+				if len(data) == 0 {
+					logrus.Info("unpack: record has zero length")
+					all_good = false
+				}
 			} else {
 				logrus.Infof("unpack: %s\n", string(data))
 			}
@@ -179,6 +184,12 @@ func unpackRecords(data unsafe.Pointer, length C.int) (records []map[interface{}
 		timestamps = append(timestamps, timestamp)
 
 		count++
+	}
+	logrus.Infof("Processed %d records", count)
+	if all_good {
+		logrus.Info("All good")
+	} else {
+		logrus.Info("Not all good")
 	}
 
 	return records, timestamps, count

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -197,7 +197,6 @@ func unpackRecords(data unsafe.Pointer, length C.int) (records []map[interface{}
 		record = records[i]
 		if record == nil {
 			logrus.Infof("unpack: %d is null\n", i)
-			continue
 		}
 		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		data, err := json.Marshal(record)

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -193,6 +193,21 @@ func unpackRecords(data unsafe.Pointer, length C.int) (records []map[interface{}
 		logrus.Info("Not all good")
 	}
 
+	for i := 0; i < count; i++ {
+		record = records[i]
+		if record == nil {
+			logrus.Infof("unpack: %d is null\n", i)
+			continue
+		}
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		data, err := json.Marshal(record)
+		if err == nil {
+			logrus.Infof("unpack: %s\n", string(data))
+		} else {
+			logrus.Info("unpack 2: unmarshal error")
+		}
+	}
+
 	return records, timestamps, count
 }
 
@@ -206,6 +221,21 @@ func pluginConcurrentFlush(ctx unsafe.Pointer, tag *C.char, count int, events []
 
 	// Each flush must have its own output buffe r, since flushes can be concurrent
 	records := make([]*kinesisAPI.PutRecordsRequestEntry, 0, maximumRecordsPerPut)
+
+	for i := 0; i < count; i++ {
+		event = events[i]
+		if event == nil {
+			logrus.Infof("flush: %d is null\n", i)
+			continue
+		}
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		data, err := json.Marshal(event)
+		if err == nil {
+			logrus.Infof("flush: %s\n", string(data))
+		} else {
+			logrus.Info("flush: unmarshal error")
+		}
+	}
 
 	for i := 0; i < count; i++ {
 		event = events[i]

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -175,8 +175,6 @@ func unpackRecords(data unsafe.Pointer, length C.int) (records []map[interface{}
 					logrus.Info("unpack: record has zero length")
 					all_good = false
 				}
-			} else {
-				logrus.Infof("unpack: %s\n", string(data))
 			}
 		}
 

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -26,6 +26,7 @@ import (
 	"github.com/fluent/fluent-bit-go/output"
 	"github.com/sirupsen/logrus"
 )
+import jsoniter "github.com/json-iterator/go"
 
 const (
 	// Kinesis API Limit https://docs.aws.amazon.com/sdk-for-go/api/service/kinesis/#Kinesis.PutRecords
@@ -160,6 +161,18 @@ func unpackRecords(data unsafe.Pointer, length C.int) (records []map[interface{}
 			timestamp = time.Unix(int64(tts), 0)
 		default:
 			timestamp = time.Now()
+		}
+
+		if record == nil {
+			logrus.Info("unpack: null record")
+		} else {
+			var json = jsoniter.ConfigCompatibleWithStandardLibrary
+			data, err := json.Marshal(record)
+			if err != nil {
+				logrus.Infof("unpack: %s\n", err)
+			} else {
+				logrus.Infof("unpack: %s\n", string(data))
+			}
 		}
 
 		records = append(records, record)

--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -197,8 +197,8 @@ func (outputPlugin *OutputPlugin) AddRecord(records *[]*kinesis.PutRecordsReques
 		retCode, err := outputPlugin.sendCurrentBatch(records)
 		if err != nil {
 			logrus.Errorf("[kinesis %d] %v\n", outputPlugin.PluginID, err)
+			return retCode
 		}
-		return retCode
 	}
 
 	*records = append(*records, &kinesis.PutRecordsRequestEntry{

--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -208,6 +208,8 @@ func (outputPlugin *OutputPlugin) Flush(records *[]*kinesis.PutRecordsRequestEnt
 			retCode, err := outputPlugin.sendCurrentBatch(&requestBuf, &dataLength)
 			if err != nil {
 				logrus.Errorf("[kinesis %d] %v\n", outputPlugin.PluginID, err)
+			}
+			if retCode != fluentbit.FLB_OK {
 				return retCode
 			}
 		}

--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -189,8 +189,6 @@ func (outputPlugin *OutputPlugin) AddRecord(records *[]*kinesis.PutRecordsReques
 		return fluentbit.FLB_OK
 	}
 
-	logrus.Infof("Adding record %s\n", string(data))
-
 	*records = append(*records, &kinesis.PutRecordsRequestEntry{
 		Data:         data,
 		PartitionKey: aws.String(partitionKey),
@@ -261,7 +259,6 @@ func (outputPlugin *OutputPlugin) processRecord(record map[interface{}]interface
 
 func (outputPlugin *OutputPlugin) sendCurrentBatch(records *[]*kinesis.PutRecordsRequestEntry, dataLength *int) (int, error) {
 	if len(*records) == 0 {
-		logrus.Info("No records")
 		return fluentbit.FLB_OK, nil
 	}
 	if outputPlugin.lastInvalidPartitionKeyIndex >= 0 && outputPlugin.lastInvalidPartitionKeyIndex <= len(*records) {

--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -191,7 +191,7 @@ func (outputPlugin *OutputPlugin) AddRecord(records *[]*kinesis.PutRecordsReques
 		return fluentbit.FLB_OK
 	}
 
-	logrus.Infof("Processing record %\ns", string(data))
+	logrus.Infof("Processing record %s\n", string(data))
 
 	newRecordSize := len(data) + len(partitionKey)
 

--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -251,7 +251,12 @@ func (outputPlugin *OutputPlugin) processRecord(record map[interface{}]interface
 }
 
 func (outputPlugin *OutputPlugin) sendCurrentBatch(records []*kinesis.PutRecordsRequestEntry) (int, error) {
+	if len(records) == 0 {
+		return fluentbit.FLB_OK, nil
+	}
 	if outputPlugin.lastInvalidPartitionKeyIndex >= 0 {
+		logrus.Infof("lastInvalidPartitionKeyIndex: %d\n", outputPlugin.lastInvalidPartitionKeyIndex)
+		logrus.Infof("len(records): %d\n", len(records))
 		logrus.Errorf("[kinesis %d] Invalid partition key. Failed to find partition_key %s in log record %s", outputPlugin.PluginID, outputPlugin.partitionKey, records[outputPlugin.lastInvalidPartitionKeyIndex].Data)
 		outputPlugin.lastInvalidPartitionKeyIndex = -1
 	}

--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -82,7 +82,6 @@ type OutputPlugin struct {
 	client                       PutRecordsClient
 	records                      []*kinesis.PutRecordsRequestEntry
 	dataLength                   int
-	backoff                      *plugins.Backoff
 	timer                        *plugins.Timeout
 	PluginID                     int
 	random                       *random
@@ -134,7 +133,6 @@ func NewOutputPlugin(region, stream, dataKeys, partitionKey, roleARN, endpoint, 
 		timeKey:                      timeKey,
 		fmtStrftime:                  timeFormatter,
 		lastInvalidPartitionKeyIndex: -1,
-		backoff:                      plugins.NewBackoff(),
 		timer:                        timer,
 		PluginID:                     pluginID,
 		random:                       random,
@@ -199,12 +197,11 @@ func (outputPlugin *OutputPlugin) AddRecord(record map[interface{}]interface{}, 
 	newRecordSize := len(data) + len(partitionKey)
 
 	if len(outputPlugin.records) == maximumRecordsPerPut || (outputPlugin.dataLength+newRecordSize) > maximumPutRecordBatchSize {
-		err = outputPlugin.sendCurrentBatch()
+		retCode, err := outputPlugin.sendCurrentBatch()
 		if err != nil {
 			logrus.Errorf("[kinesis %d] %v\n", outputPlugin.PluginID, err)
-			// If FluentBit fails to send logs, it will retry rather than discarding the logs
-			return fluentbit.FLB_RETRY
 		}
+		return retCode
 	}
 
 	outputPlugin.records = append(outputPlugin.records, &kinesis.PutRecordsRequestEntry{
@@ -216,8 +213,13 @@ func (outputPlugin *OutputPlugin) AddRecord(record map[interface{}]interface{}, 
 }
 
 // Flush sends the current buffer of log records
-func (outputPlugin *OutputPlugin) Flush() error {
-	return outputPlugin.sendCurrentBatch()
+// Returns FLB_OK, FLB_RETRY, FLB_ERROR
+func (outputPlugin *OutputPlugin) Flush() int {
+	retCode, err := outputPlugin.sendCurrentBatch()
+	if err != nil {
+		logrus.Errorf("[kinesis %d] %v\n", outputPlugin.PluginID, err)
+	}
+	return retCode
 }
 
 func (outputPlugin *OutputPlugin) processRecord(record map[interface{}]interface{}, partitionKey string) ([]byte, error) {
@@ -251,12 +253,11 @@ func (outputPlugin *OutputPlugin) processRecord(record map[interface{}]interface
 	return data, nil
 }
 
-func (outputPlugin *OutputPlugin) sendCurrentBatch() error {
+func (outputPlugin *OutputPlugin) sendCurrentBatch() (int, error) {
 	if outputPlugin.lastInvalidPartitionKeyIndex >= 0 {
 		logrus.Errorf("[kinesis %d] Invalid partition key. Failed to find partition_key %s in log record %s", outputPlugin.PluginID, outputPlugin.partitionKey, outputPlugin.records[outputPlugin.lastInvalidPartitionKeyIndex].Data)
 		outputPlugin.lastInvalidPartitionKeyIndex = -1
 	}
-	outputPlugin.backoff.Wait()
 	outputPlugin.timer.Check()
 
 	response, err := outputPlugin.client.PutRecords(&kinesis.PutRecordsInput{
@@ -269,11 +270,9 @@ func (outputPlugin *OutputPlugin) sendCurrentBatch() error {
 		if aerr, ok := err.(awserr.Error); ok {
 			if aerr.Code() == kinesis.ErrCodeProvisionedThroughputExceededException {
 				logrus.Warnf("[kinesis %d] Throughput limits for the stream may have been exceeded.", outputPlugin.PluginID)
-				// Backoff and Retry
-				outputPlugin.backoff.StartBackoff()
 			}
 		}
-		return err
+		return fluentbit.FLB_RETRY, err
 	}
 	logrus.Debugf("[kinesis %d] Sent %d events to Kinesis\n", outputPlugin.PluginID, len(outputPlugin.records))
 
@@ -282,12 +281,12 @@ func (outputPlugin *OutputPlugin) sendCurrentBatch() error {
 
 // processAPIResponse processes the successful and failed records
 // it returns an error iff no records succeeded (i.e.) no progress has been made
-func (outputPlugin *OutputPlugin) processAPIResponse(response *kinesis.PutRecordsOutput) error {
+func (outputPlugin *OutputPlugin) processAPIResponse(response *kinesis.PutRecordsOutput) (int, error) {
 	if aws.Int64Value(response.FailedRecordCount) > 0 {
 		// start timer if all records failed (no progress has been made)
 		if aws.Int64Value(response.FailedRecordCount) == int64(len(outputPlugin.records)) {
 			outputPlugin.timer.Start()
-			return fmt.Errorf("PutRecords request returned with no records successfully recieved")
+			return fluentbit.FLB_RETRY, fmt.Errorf("PutRecords request returned with no records successfully recieved")
 		}
 
 		logrus.Warnf("[kinesis %d] %d records failed to be delivered. Will retry.\n", outputPlugin.PluginID, aws.Int64Value(response.FailedRecordCount))
@@ -299,8 +298,8 @@ func (outputPlugin *OutputPlugin) processAPIResponse(response *kinesis.PutRecord
 				failedRecords = append(failedRecords, outputPlugin.records[i])
 			}
 			if aws.StringValue(record.ErrorCode) == kinesis.ErrCodeProvisionedThroughputExceededException {
-				// Backoff and Retry
-				outputPlugin.backoff.StartBackoff()
+				logrus.Warnf("[kinesis %d] Throughput limits for the stream may have been exceeded.", outputPlugin.PluginID)
+				return fluentbit.FLB_RETRY, nil
 			}
 		}
 
@@ -313,11 +312,10 @@ func (outputPlugin *OutputPlugin) processAPIResponse(response *kinesis.PutRecord
 	} else {
 		// request fully succeeded
 		outputPlugin.timer.Reset()
-		outputPlugin.backoff.Reset()
 		outputPlugin.records = outputPlugin.records[:0]
 		outputPlugin.dataLength = 0
 	}
-	return nil
+	return fluentbit.FLB_OK, nil
 }
 
 // randomString generates a random string of length 8

--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -191,6 +191,8 @@ func (outputPlugin *OutputPlugin) AddRecord(records *[]*kinesis.PutRecordsReques
 		return fluentbit.FLB_OK
 	}
 
+	logrus.Infof("Processing record %\ns", string(data))
+
 	newRecordSize := len(data) + len(partitionKey)
 
 	if len(*records) == maximumRecordsPerPut || (outputPlugin.dataLength+newRecordSize) > maximumPutRecordBatchSize {

--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -262,12 +262,10 @@ func (outputPlugin *OutputPlugin) sendCurrentBatch(records *[]*kinesis.PutRecord
 		return fluentbit.FLB_OK, nil
 	}
 	outputPlugin.timer.Check()
-	logrus.Infof("About to send %d records to %s", len(*records), outputPlugin.stream)
 	response, err := outputPlugin.client.PutRecords(&kinesis.PutRecordsInput{
 		Records:    *records,
 		StreamName: aws.String(outputPlugin.stream),
 	})
-	logrus.Infof("Tried to send %d records", len(*records))
 	if err != nil {
 		logrus.Errorf("[kinesis %d] PutRecords failed with %v\n", outputPlugin.PluginID, err)
 		outputPlugin.timer.Start()

--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -252,6 +252,7 @@ func (outputPlugin *OutputPlugin) processRecord(record map[interface{}]interface
 
 func (outputPlugin *OutputPlugin) sendCurrentBatch(records []*kinesis.PutRecordsRequestEntry) (int, error) {
 	if len(records) == 0 {
+		logrus.Info("No records")
 		return fluentbit.FLB_OK, nil
 	}
 	if outputPlugin.lastInvalidPartitionKeyIndex >= 0 && outputPlugin.lastInvalidPartitionKeyIndex <= len(records) {
@@ -264,7 +265,7 @@ func (outputPlugin *OutputPlugin) sendCurrentBatch(records []*kinesis.PutRecords
 		Records:    records,
 		StreamName: aws.String(outputPlugin.stream),
 	})
-	logrus.Infof("Tried send %d records", len(records))
+	logrus.Infof("Tried to send %d records", len(records))
 	if err != nil {
 		logrus.Errorf("[kinesis %d] PutRecords failed with %v\n", outputPlugin.PluginID, err)
 		outputPlugin.timer.Start()

--- a/kinesis/kinesis_test.go
+++ b/kinesis/kinesis_test.go
@@ -40,7 +40,6 @@ func newMockOutputPlugin(client *mock_kinesis.MockPutRecordsClient) (*OutputPlug
 		dataKeys:                     "",
 		partitionKey:                 "",
 		lastInvalidPartitionKeyIndex: -1,
-		backoff:                      plugins.NewBackoff(),
 		timer:                        timer,
 		PluginID:                     0,
 		random:                       random,
@@ -98,6 +97,6 @@ func TestAddRecordAndFlush(t *testing.T) {
 	retCode := outputPlugin.AddRecord(record, &timeStamp)
 	assert.Equal(t, retCode, fluentbit.FLB_OK, "Expected return code to be FLB_OK")
 
-	err := outputPlugin.Flush()
-	assert.NoError(t, err, "Unexpected error calling flush")
+	retCode = outputPlugin.Flush()
+	assert.Equal(t, retCode, fluentbit.FLB_OK, "Expected return code to be FLB_OK")
 }


### PR DESCRIPTION
*Issue #, if available:*
Related to: https://github.com/fluent/fluent-bit/issues/2159

*Description of changes:*
Previously, this plugin was synchronous. Since Fluent Bit is single-threaded, this decreases performance. Native C plugins in Fluent Bit core can take advantage of its event loop to asynchronously make requests. Go plugins are not as fancy. With this change, the plugin returns control to Fluent Bit immediately and sends data in a goroutine. I've previously verified that the goroutines are proper separate threads and continue running even after control returns to the Fluent Bit C code. 

The downside to this change is that plugins will not accurately report errors or retries to Fluent Bit. I'm considering making this change an optional mode that is turned off by default and users can opt into if they want.

Long term of course, we will rewrite this plugin C and contribute it to the core of Fluent Bit, giving us performance and concurrency without the above drawback.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
