### PR TITLE
add millisecond and microsecond format strings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/fluent/fluent-bit-go v0.0.0-20190925192703-ea13c021720c
 	github.com/golang/mock v1.3.1
 	github.com/json-iterator/go v1.1.7
-	github.com/lestrrat-go/strftime v1.0.1
+	github.com/lestrrat-go/strftime v1.0.2-0.20200618102204-1b0bc59fa4ab
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc h1:RKf14vYWi2t
 github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc/go.mod h1:kopuH9ugFRkIXf3YoqHKyrJ9YfUFsckUU9S7B+XP+is=
 github.com/lestrrat-go/strftime v1.0.1 h1:o7qz5pmLzPDLyGW4lG6JvTKPUfTFXwe+vOamIYWtnVU=
 github.com/lestrrat-go/strftime v1.0.1/go.mod h1:E1nN3pCbtMSu1yjSVeyuRFVm/U0xoR76fd03sz+Qz4g=
+github.com/lestrrat-go/strftime v1.0.2-0.20200618102204-1b0bc59fa4ab h1:rJi8p3M7kABzb4Cw2JiUr01VwTPDc50CqKkn6CR6Si0=
+github.com/lestrrat-go/strftime v1.0.2-0.20200618102204-1b0bc59fa4ab/go.mod h1:E1nN3pCbtMSu1yjSVeyuRFVm/U0xoR76fd03sz+Qz4g=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -116,7 +116,7 @@ func NewOutputPlugin(region, stream, dataKeys, partitionKey, roleARN, endpoint, 
 		if timeFmt == "" {
 			timeFmt = defaultTimeFmt
 		}
-		timeFormatter, err = strftime.New(timeFmt)
+		timeFormatter, err = strftime.New(timeFmt, strftime.WithMilliseconds('L'), strftime.WithMicroseconds('f'))
 		if err != nil {
 			logrus.Errorf("[kinesis %d] Issue with strftime format in 'time_key_format'", pluginID)
 			return nil, err


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-kinesis-streams-for-fluent-bit/issues/34

*Description of changes:*

It's important when looking at time-ordered logs to have resolution
below a second. I think this benefit outweighs being strictly
POSIX-compliant. This change allows for the format specifiers `%L` for
milliseconds and `%f` for microseconds, which are the format strings
used in the extensions provided by the github.com/lestrrat-go/strftime
library.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
