### PR TITLE
Print the plugin version with name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,13 @@ all: build
 
 SOURCES := $(shell find . -name '*.go')
 PLUGIN_BINARY := ./bin/kinesis.so
+PLUGIN_VERSION := $(shell cat VERSION)
 
 .PHONY: release
 release:
 	mkdir -p ./bin
 	go build -buildmode c-shared -o ./bin/kinesis.so ./
-	@echo "Built Amazon Kinesis Data Streams Fluent Bit Plugin"
+	@echo "Built Amazon Kinesis Data Streams Fluent Bit Plugin v$(PLUGIN_VERSION)"
 
 .PHONY: build
 build: $(PLUGIN_BINARY) release


### PR DESCRIPTION
*Description of changes:*
When the plugin is built, it prints the name. It might be cool if we print the version as well. It will help to be sure that we are building the correct version. 
If we agree on this, we can do the same for our other plugins. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
