### PR TITLE
Truncate Large Log Events

### DIFF
--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -42,6 +42,7 @@ import (
 
 const (
 	partitionKeyCharset = "abcdefghijklmnopqrstuvwxyz" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	truncatedSuffix     = "[Truncated...]"
 )
 
 const (
@@ -418,7 +419,9 @@ func (outputPlugin *OutputPlugin) processRecord(record map[interface{}]interface
 	}
 
 	if len(data)+len(partitionKey) > maximumRecordSize {
-		return nil, fmt.Errorf("Log record greater than max size allowed by Kinesis")
+		logrus.Warnf("[kinesis %d] Found record with %d bytes, truncating to 1MB, stream=%s\n", outputPlugin.PluginID, len(data)+len(partitionKey), outputPlugin.stream)
+		data = data[:maximumRecordSize-len(partitionKey)-len(truncatedSuffix)]
+		data = append(data, []byte(truncatedSuffix)...)
 	}
 
 	return data, nil


### PR DESCRIPTION
*Issue [https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit/issues/58](https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit/issues/58)

*Description of changes:*
Truncate the large log events rather than discarding them if their size is larger than the maximum size

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
