### PR TITLE
Replace Dots in Key names with underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you think you’ve found a potential security issue, please do not post it in
 * `experimental_concurrency_retries`: Specify a limit to the number of retries concurrent goroutines will attempt.  By default `4` retries will be attempted before records are dropped.
 * `aggregation`: Setting `aggregation` to `true` will enable KPL aggregation of records sent to Kinesis.  This feature isn't compatible with the `partition_key` feature.  See the KPL aggregation section below for more details.
 * `compression`: Setting `compression` to `zlib` will enable zlib compression of each record.  By default this feature is disabled and records are not compressed.
-* `replace_dots`: A string which will be what you replace the dots in the key name with. By default, it will be empty which means the feature is disabled.
+* `replace_dots`: Replace dot characters in key names with the value of this option. For example, if you add `replace_dots _` in your config then all occurrences of `.` will be replaced with an underscore. By default, dots will not be replaced.
 
 ### Permissions
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you think you’ve found a potential security issue, please do not post it in
 * `experimental_concurrency_retries`: Specify a limit to the number of retries concurrent goroutines will attempt.  By default `4` retries will be attempted before records are dropped.
 * `aggregation`: Setting `aggregation` to `true` will enable KPL aggregation of records sent to Kinesis.  This feature isn't compatible with the `partition_key` feature.  See the KPL aggregation section below for more details.
 * `compression`: Setting `compression` to `zlib` will enable zlib compression of each record.  By default this feature is disabled and records are not compressed.
+* `replace_dots`: If you set replace_dots as true, all dots in key names will be replaced with underscores.
 
 ### Permissions
 
@@ -57,6 +58,7 @@ This plugin has been tested with Fluent Bit 1.2.0+. It may not work with older F
     stream          my-kinesis-stream-name
     partition_key   container_id
     append_newline  true
+    replace_dots    true
 ```
 
 ### AWS for Fluent Bit

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you think you’ve found a potential security issue, please do not post it in
 * `experimental_concurrency_retries`: Specify a limit to the number of retries concurrent goroutines will attempt.  By default `4` retries will be attempted before records are dropped.
 * `aggregation`: Setting `aggregation` to `true` will enable KPL aggregation of records sent to Kinesis.  This feature isn't compatible with the `partition_key` feature.  See the KPL aggregation section below for more details.
 * `compression`: Setting `compression` to `zlib` will enable zlib compression of each record.  By default this feature is disabled and records are not compressed.
-* `replace_dots`: If you set replace_dots as true, all dots in key names will be replaced with underscores.
+* `replace_dots`: A string which will be what you replace the dots in the key name with. By default, it will be empty which means the feature is disabled.
 
 ### Permissions
 
@@ -58,7 +58,7 @@ This plugin has been tested with Fluent Bit 1.2.0+. It may not work with older F
     stream          my-kinesis-stream-name
     partition_key   container_id
     append_newline  true
-    replace_dots    true
+    replace_dots    _
 ```
 
 ### AWS for Fluent Bit
@@ -131,7 +131,6 @@ More specifically, increasing the flush value will ensure the most records are a
     stream          my-kinesis-stream-name
     aggregation     true
     append_newline  true
-    replace_dots    true
 ```
 
 ### ZLIB Compression
@@ -167,5 +166,4 @@ Example config:
     stream          my-kinesis-stream-name
     compression     zlib
     append_newline  true
-    replace_dots    true
 ```

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ More specifically, increasing the flush value will ensure the most records are a
     stream          my-kinesis-stream-name
     aggregation     true
     append_newline  true
+    replace_dots    true
 ```
 
 ### ZLIB Compression
@@ -166,4 +167,5 @@ Example config:
     stream          my-kinesis-stream-name
     compression     zlib
     append_newline  true
+    replace_dots    true
 ```

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -87,6 +87,8 @@ func newKinesisOutput(ctx unsafe.Pointer, pluginID int) (*kinesis.OutputPlugin, 
 	logrus.Infof("[kinesis %d] plugin parameter aggregation = '%s'", pluginID, aggregation)
 	compression := output.FLBPluginConfigKey(ctx, "compression")
 	logrus.Infof("[kinesis %d] plugin parameter compression = '%s'", pluginID, compression)
+	replaceDots := output.FLBPluginConfigKey(ctx, "replace_dots")
+	logrus.Infof("[kinesis %d] plugin parameter replace_dots = %s", pluginID, replaceDots)
 
 	if stream == "" || region == "" {
 		return nil, fmt.Errorf("[kinesis %d] stream and region are required configuration parameters", pluginID)
@@ -103,6 +105,11 @@ func newKinesisOutput(ctx unsafe.Pointer, pluginID int) (*kinesis.OutputPlugin, 
 	appendNL := false
 	if strings.ToLower(appendNewline) == "true" {
 		appendNL = true
+	}
+
+	replaceDotsInKeys := false
+	if strings.ToLower(replaceDots) == "true" {
+		replaceDotsInKeys = true
 	}
 
 	isAggregate := false
@@ -156,7 +163,7 @@ func newKinesisOutput(ctx unsafe.Pointer, pluginID int) (*kinesis.OutputPlugin, 
 		return nil, fmt.Errorf("[kinesis %d] Invalid 'compression' value (%s) specified, must be 'zlib', 'none', or undefined", pluginID, compression)
 	}
 
-	return kinesis.NewOutputPlugin(region, stream, dataKeys, partitionKey, roleARN, kinesisEndpoint, stsEndpoint, timeKey, timeKeyFmt, logKey, concurrencyInt, concurrencyRetriesInt, isAggregate, appendNL, comp, pluginID)
+	return kinesis.NewOutputPlugin(region, stream, dataKeys, partitionKey, roleARN, kinesisEndpoint, stsEndpoint, timeKey, timeKeyFmt, logKey, concurrencyInt, concurrencyRetriesInt, isAggregate, appendNL, replaceDotsInKeys, comp, pluginID)
 }
 
 // The "export" comments have syntactic meaning

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -88,7 +88,7 @@ func newKinesisOutput(ctx unsafe.Pointer, pluginID int) (*kinesis.OutputPlugin, 
 	compression := output.FLBPluginConfigKey(ctx, "compression")
 	logrus.Infof("[kinesis %d] plugin parameter compression = '%s'", pluginID, compression)
 	replaceDots := output.FLBPluginConfigKey(ctx, "replace_dots")
-	logrus.Infof("[kinesis %d] plugin parameter replace_dots = %s", pluginID, replaceDots)
+	logrus.Infof("[kinesis %d] plugin parameter replace_dots = '%s'", pluginID, replaceDots)
 
 	if stream == "" || region == "" {
 		return nil, fmt.Errorf("[kinesis %d] stream and region are required configuration parameters", pluginID)
@@ -107,9 +107,8 @@ func newKinesisOutput(ctx unsafe.Pointer, pluginID int) (*kinesis.OutputPlugin, 
 		appendNL = true
 	}
 
-	replaceDotsInKeys := false
-	if strings.ToLower(replaceDots) == "true" {
-		replaceDotsInKeys = true
+	if replaceDots == "" {
+		logrus.Infof("[kinesis %d] No replacement provided. Do not need to replace dots with other symbols.", pluginID)
 	}
 
 	isAggregate := false
@@ -163,7 +162,7 @@ func newKinesisOutput(ctx unsafe.Pointer, pluginID int) (*kinesis.OutputPlugin, 
 		return nil, fmt.Errorf("[kinesis %d] Invalid 'compression' value (%s) specified, must be 'zlib', 'none', or undefined", pluginID, compression)
 	}
 
-	return kinesis.NewOutputPlugin(region, stream, dataKeys, partitionKey, roleARN, kinesisEndpoint, stsEndpoint, timeKey, timeKeyFmt, logKey, concurrencyInt, concurrencyRetriesInt, isAggregate, appendNL, replaceDotsInKeys, comp, pluginID)
+	return kinesis.NewOutputPlugin(region, stream, dataKeys, partitionKey, roleARN, kinesisEndpoint, stsEndpoint, timeKey, timeKeyFmt, logKey, replaceDots, concurrencyInt, concurrencyRetriesInt, isAggregate, appendNL, comp, pluginID)
 }
 
 // The "export" comments have syntactic meaning

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -107,10 +107,6 @@ func newKinesisOutput(ctx unsafe.Pointer, pluginID int) (*kinesis.OutputPlugin, 
 		appendNL = true
 	}
 
-	if replaceDots == "" {
-		logrus.Infof("[kinesis %d] No replacement provided. Do not need to replace dots with other symbols.", pluginID)
-	}
-
 	isAggregate := false
 	if strings.ToLower(aggregation) == "true" {
 		isAggregate = true

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,7 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fluent/fluent-bit-go v0.0.0-20200707230002-2a28684e2382 h1:gV8vs5nuIWEbCn/EnHa8/2VEbFcGpchUhqftnxHSOrI=
 github.com/fluent/fluent-bit-go v0.0.0-20200707230002-2a28684e2382/go.mod h1:L92h+dgwElEyUuShEwjbiHjseW410WIcNz+Bjutc8YQ=
+github.com/fluent/fluent-bit-go v0.0.0-20200729034236-b9c0d6a20853 h1:QapwPpeMtcxkG6WjcQQneyGtVSsr4meJ0Fz4B2T3j/c=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -108,10 +109,12 @@ type OutputPlugin struct {
 	aggregator            *aggregate.Aggregator
 	aggregatePartitionKey string
 	compression           CompressionType
+	// Decide whether dots in key names should be replaced with underscores
+	replaceDots bool
 }
 
 // NewOutputPlugin creates an OutputPlugin object
-func NewOutputPlugin(region, stream, dataKeys, partitionKey, roleARN, kinesisEndpoint, stsEndpoint, timeKey, timeFmt, logKey string, concurrency, retryLimit int, isAggregate, appendNewline bool, compression CompressionType, pluginID int) (*OutputPlugin, error) {
+func NewOutputPlugin(region, stream, dataKeys, partitionKey, roleARN, kinesisEndpoint, stsEndpoint, timeKey, timeFmt, logKey string, concurrency, retryLimit int, isAggregate, appendNewline, replaceDots bool, compression CompressionType, pluginID int) (*OutputPlugin, error) {
 	client, err := newPutRecordsClient(roleARN, region, kinesisEndpoint, stsEndpoint, pluginID)
 	if err != nil {
 		return nil, err
@@ -167,6 +170,7 @@ func NewOutputPlugin(region, stream, dataKeys, partitionKey, roleARN, kinesisEnd
 		isAggregate:           isAggregate,
 		aggregator:            aggregator,
 		compression:           compression,
+		replaceDots:           replaceDots,
 	}, nil
 }
 
@@ -402,6 +406,32 @@ func (outputPlugin *OutputPlugin) FlushConcurrent(count int, records []*kinesis.
 
 }
 
+func replaceDots(obj map[interface{}]interface{}) map[interface{}]interface{} {
+	newObj := make(map[interface{}]interface{})
+
+	for k, v := range obj {
+		switch kt := k.(type) {
+		case string:
+			k = strings.ReplaceAll(kt, ".", "_")
+		}
+
+		switch vt := v.(type) {
+		case map[interface{}]interface{}:
+			v = replaceDots(vt)
+			// Ensure duplicated keys are merged rather than replaced
+			if _, ok := newObj[k]; ok {
+				for nestedK, nestedV := range vt {
+					newObj[k].(map[interface{}]interface{})[nestedK] = nestedV
+				}
+			}
+		}
+
+		newObj[k] = v
+	}
+
+	return newObj
+}
+
 func (outputPlugin *OutputPlugin) processRecord(record map[interface{}]interface{}, partitionKey string) ([]byte, error) {
 	if outputPlugin.dataKeys != "" {
 		record = plugins.DataKeys(outputPlugin.dataKeys, record)
@@ -412,6 +442,10 @@ func (outputPlugin *OutputPlugin) processRecord(record map[interface{}]interface
 	if err != nil {
 		logrus.Debugf("[kinesis %d] Failed to decode record: %v\n", outputPlugin.PluginID, record)
 		return nil, err
+	}
+
+	if outputPlugin.replaceDots {
+		record = replaceDots(record)
 	}
 
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary

--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -408,17 +408,18 @@ func (outputPlugin *OutputPlugin) FlushConcurrent(count int, records []*kinesis.
 
 func replaceDots(obj map[interface{}]interface{}) map[interface{}]interface{} {
 	for k, v := range obj {
+		var curK = k
 		switch kt := k.(type) {
 		case string:
-			k = strings.ReplaceAll(kt, ".", "_")
+			curK = strings.ReplaceAll(kt, ".", "_")
 		}
-
+		delete(obj, k)
 		switch vt := v.(type) {
 		case map[interface{}]interface{}:
 			v = replaceDots(vt)
 		}
 
-		obj[k] = v
+		obj[curK] = v
 	}
 
 	return obj

--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -407,8 +407,6 @@ func (outputPlugin *OutputPlugin) FlushConcurrent(count int, records []*kinesis.
 }
 
 func replaceDots(obj map[interface{}]interface{}) map[interface{}]interface{} {
-	newObj := make(map[interface{}]interface{})
-
 	for k, v := range obj {
 		switch kt := k.(type) {
 		case string:
@@ -418,18 +416,12 @@ func replaceDots(obj map[interface{}]interface{}) map[interface{}]interface{} {
 		switch vt := v.(type) {
 		case map[interface{}]interface{}:
 			v = replaceDots(vt)
-			// Ensure duplicated keys are merged rather than replaced
-			if _, ok := newObj[k]; ok {
-				for nestedK, nestedV := range vt {
-					newObj[k].(map[interface{}]interface{})[nestedK] = nestedV
-				}
-			}
 		}
 
-		newObj[k] = v
+		obj[k] = v
 	}
 
-	return newObj
+	return obj
 }
 
 func (outputPlugin *OutputPlugin) processRecord(record map[interface{}]interface{}, partitionKey string) ([]byte, error) {

--- a/kinesis/kinesis_test.go
+++ b/kinesis/kinesis_test.go
@@ -208,6 +208,7 @@ func TestZlibCompressionEmpty(t *testing.T) {
 }
 
 func TestDotReplace(t *testing.T) {
+	records := make([]*kinesis.PutRecordsRequestEntry, 0, 500)
 	record := map[interface{}]interface{}{
 		"testkey": []byte("test value"),
 		"kubernetes": map[interface{}]interface{}{
@@ -216,13 +217,14 @@ func TestDotReplace(t *testing.T) {
 		},
 	}
 
-	outputPlugin, _ := newMockOutputPlugin(nil)
+	outputPlugin, _ := newMockOutputPlugin(nil, false)
 
-	retCode := outputPlugin.AddRecord(record)
+	timeStamp := time.Now()
+	retCode := outputPlugin.AddRecord(&records, record, &timeStamp)
 	assert.Equal(t, retCode, fluentbit.FLB_OK, "Expected return code to be FLB_OK")
-	assert.Len(t, outputPlugin.records, 1, "Expected output to contain 1 record")
+	assert.Len(t, records, 1, "Expected output to contain 1 record")
 
-	data := outputPlugin.records[0].Data
+	data := records[0].Data
 
 	var log map[string]map[string]interface{}
 	json.Unmarshal(data, &log)


### PR DESCRIPTION
*Issue [https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit/issues/46](https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit/issues/46)

*Description of changes:*
Replace Dots in Key names with underscores

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
