### PR TITLE
Automatically package and release the plugin binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: BuildAndRelease
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  build:
+    name: BuildAndRelease
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.15
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15
+      id: go
+
+    - name: Set env
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: golint
+      run: go get -u golang.org/x/lint/golint
+
+    - name: Build
+      run: make build test
+
+    - name: Package
+      run: make release
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: AWS Kinesis Streams for Fluent Bit ${{ env.RELEASE_VERSION }}
+        draft: false
+        prerelease: false
+
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./plugin.tgz
+        asset_name: plugin-${{ env.RELEASE_VERSION }}.tgz
+        asset_content_type: application/x-gzip
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,16 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
+    - name: Install aarch64 deps
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-aarch64-linux-gnu
+
     - name: golint
       run: go get -u golang.org/x/lint/golint
 
     - name: Build
       run: make build test
-
-    - name: Package
-      run: make release
 
     - name: Create Release
       id: create_release
@@ -42,14 +44,41 @@ jobs:
         draft: false
         prerelease: false
 
-    - name: Upload Release Asset
-      id: upload-release-asset 
+    - name: Package AMD
+      run: |
+        go clean
+        make clean
+        make build
+
+    - name: Upload Release Asset (amd64)
+      id: upload-release-asset-amd64
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./plugin.tgz
-        asset_name: plugin-${{ env.RELEASE_VERSION }}.tgz
+        asset_name: plugin-${{ env.RELEASE_VERSION }}-amd64.tgz
         asset_content_type: application/x-gzip
 
+    - name: Package ARM
+      env:
+        CGO_ENABLED: '1'
+        CC: aarch64-linux-gnu-gcc
+        GOOS: linux
+        GOARCH: arm64
+      run: |
+        go clean
+        make clean
+        make build
+
+    - name: Upload Release Asset (aarch64)
+      id: upload-release-asset-aarch64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./plugin.tgz
+        asset_name: plugin-${{ env.RELEASE_VERSION }}-aarch64.tgz
+        asset_content_type: application/x-gzip

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,13 @@ release:
 	@echo "Built Amazon Kinesis Data Streams Fluent Bit Plugin v$(PLUGIN_VERSION)"
 
 .PHONY: build
-build: $(PLUGIN_BINARY) release
+build: $(PLUGIN_BINARY) release plugin.tgz
 
 $(PLUGIN_BINARY): $(SOURCES)
 	PATH=${PATH} golint ./kinesis	
+
+plugin.tgz: $(PLUGIN_BINARY)
+	tar --strip-components 1 -zcvf plugin.tgz $(PLUGIN_BINARY)
 
 .PHONY: generate
 generate: $(SOURCES)

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ $(PLUGIN_BINARY): $(SOURCES)
 	PATH=${PATH} golint ./kinesis	
 
 plugin.tgz: $(PLUGIN_BINARY)
-	tar --strip-components 1 -zcvf plugin.tgz $(PLUGIN_BINARY)
+	tar --strip-components 2 -zcvf plugin.tgz $(PLUGIN_BINARY)
 
 .PHONY: generate
 generate: $(SOURCES)


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This change uses Github actions to package up the plugin binary so that it can be downloaded directly from Github. This supports users who are running Fluentbit natively (via Debian or Redhat packages) but want to leverage these plugins.