### PR TITLE
Fix partition key computation for aggregation

### DIFF
--- a/aggregate/aggregator_test.go
+++ b/aggregate/aggregator_test.go
@@ -3,19 +3,34 @@ package aggregate
 import (
 	"testing"
 
+	"github.com/aws/amazon-kinesis-streams-for-fluent-bit/util"
 	"github.com/stretchr/testify/assert"
 )
 
 const concurrencyRetryLimit = 4
 
 func TestAddRecordCalculatesCorrectSize(t *testing.T) {
-	aggregator := NewAggregator()
+	generator := util.NewRandomStringGenerator(18)
+	aggregator := NewAggregator(generator)
 
-	_, err := aggregator.AddRecord("test partition key", []byte("test value"))
+	_, err := aggregator.AddRecord("", false, []byte("test value"))
 	assert.Equal(t, nil, err, "Expected aggregator not to return error")
 	assert.Equal(t, 36, aggregator.aggSize, "Expected aggregator to compute correct size")
 
-	_, err = aggregator.AddRecord("test partition key 2", []byte("test value 2"))
+	_, err = aggregator.AddRecord("test partition key 2", true, []byte("test value 2"))
 	assert.Equal(t, nil, err, "Expected aggregator not to return error")
 	assert.Equal(t, 76, aggregator.aggSize, "Expected aggregator to compute correct size")
+}
+
+func TestAddRecordDoesNotAddNewRandomPartitionKey(t *testing.T) {
+	generator := util.NewRandomStringGenerator(18)
+	aggregator := NewAggregator(generator)
+
+	_, err := aggregator.AddRecord("", false, []byte("test value"))
+	assert.Equal(t, nil, err, "Expected aggregator not to return error")
+	assert.Equal(t, 36, aggregator.aggSize, "Expected aggregator to compute correct size")
+
+	_, err = aggregator.AddRecord("", false, []byte("test value 2"))
+	assert.Equal(t, nil, err, "Expected aggregator not to return error")
+	assert.Equal(t, 1, len(aggregator.partitionKeys), "Expected aggregator to reuse partitionKey value")
 }

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -113,7 +113,7 @@ func newKinesisOutput(ctx unsafe.Pointer, pluginID int) (*kinesis.OutputPlugin, 
 	}
 
 	if isAggregate && partitionKey != "" {
-		logrus.Errorf("[kinesis %d]  WARNING: The options 'aggregation' and  'partition_key' should not be used simaltaniously", pluginID)
+		logrus.Errorf("[kinesis %d]  WARNING: The options 'aggregation' and  'partition_key' should not be used simultaneously", pluginID)
 	}
 
 	var concurrencyInt, concurrencyRetriesInt int

--- a/util/random.go
+++ b/util/random.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"math/rand"
+	"time"
+)
+
+const (
+	partitionKeyCharset = "abcdefghijklmnopqrstuvwxyz" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+)
+
+type RandomStringGenerator struct {
+	seededRandom *rand.Rand
+	buffer       []byte
+	Size         int
+}
+
+// Provides a generator of random strings of provided length
+// it uses the math/rand library
+func NewRandomStringGenerator(stringSize int) *RandomStringGenerator {
+
+	return &RandomStringGenerator{
+		seededRandom: rand.New(rand.NewSource(time.Now().UnixNano())),
+		buffer:       make([]byte, stringSize),
+		Size:         stringSize,
+	}
+}
+
+func (gen *RandomStringGenerator) RandomString() string {
+	for i := range gen.buffer {
+		gen.buffer[i] = partitionKeyCharset[gen.seededRandom.Intn(len(partitionKeyCharset))]
+	}
+	return string(gen.buffer)
+}


### PR DESCRIPTION
Signed-off-by: James Elias Sigurdarson <jamiees2@gmail.com>

*Description of changes:*

The aggregator function has a bug I was wondering about earlier, but recently realized causes actual problems in our setup.  

Some notes to provide context:
When producing a record and switching over the aggregator due to size limitations, we start a new aggregation record. 
When aggregating into the complete record, we choose `pkeys[0]` to be the partition key of the Kinesis record.

The bug is that when we switch over to the new aggregation record, we don't regenerate the partition key. The partition key passed is consistent for the entire aggregation, and after returning, we regenerate this key, but we add the first record to the aggregator with the wrong partition key.

The end result is that the next aggregation record is produced with the same partition key as the previous aggregation record. Funny enough this is only a problem for the first aggregation record produced after the switch over, after which `pkeys[0]` will always never match the remaining records. 

This is a problem when the first record is right up against the 1MB shard limit, because the next record will guaranteed end up in the same shard as the first record. As a result, we see a `ErrCodeProvisionedThroughputExceededException`, and the chunk can never be submitted.


Anyway, this fixes the issue by refactoring the random string generator into a class which can be passed around, and handing control over random string generation to the aggregator itself. This felt like the most maintainable solution, but ends up refactoring the way we manage partition keys. The changes themselves aren't too bad, instead of returning a random string, `getPartitionKey` returns a `(partitionKey, ok)` tuple, which is handled differently between the aggregated and non-aggregated impl.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
