### PR TITLE
add timeout config for AWS SDK Go HTTP calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ If you think you’ve found a potential security issue, please do not post it in
 * `aggregation`: Setting `aggregation` to `true` will enable KPL aggregation of records sent to Kinesis.  This feature changes the behavior of the `partition_key` feature.  See the KPL aggregation section below for more details.
 * `compression`: Specify an algorithm for compression of each record. Supported compression algorithms are `zlib` and `gzip`. By default this feature is disabled and records are not compressed.
 * `replace_dots`: Replace dot characters in key names with the value of this option. For example, if you add `replace_dots _` in your config then all occurrences of `.` will be replaced with an underscore. By default, dots will not be replaced.
+* `http_request_timeout`: Specify a timeout (in seconds) for the underlying AWS SDK Go HTTP call when sending records to Kinesis. By default, a timeout of `0` is used, indicating no timeout. Note that even with no timeout, the default behavior of the AWS SDK Go library may still lead to an eventual timeout.
 
 ### Permissions
 

--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -358,7 +358,7 @@ func (outputPlugin *OutputPlugin) FlushWithRetries(count int, records []*kinesis
 	currentRetries := outputPlugin.getConcurrentRetries()
 	outputPlugin.addGoroutineCount(1)
 
-	for tries = 0; tries < outputPlugin.concurrencyRetryLimit; tries++ {
+	for tries = 0; tries <= outputPlugin.concurrencyRetryLimit; tries++ {
 		if currentRetries > 0 {
 			// Wait if other goroutines are retrying, as well as implement a progressive backoff
 			if currentRetries > uint32(outputPlugin.concurrencyRetryLimit) {


### PR DESCRIPTION
*Fixes #178*

*Description of changes:*
This PR adds a new configuration to customize the timeout in the HTTP client being used by the AWS SDK Go `PutRecords` calls. It is based on guidance specified in the [SDK docs](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/custom-http.html). All other default settings in the HTTP client being used will stay the same.

It has been tested and verified via local builds/patches (both specifying a config and leaving it out to default to existing behavior).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
